### PR TITLE
Regex fix and plugin model Fix

### DIFF
--- a/views/helpers/validation.php
+++ b/views/helpers/validation.php
@@ -44,6 +44,8 @@ class ValidationHelper extends Helper {
     //filter the rules to those that can be handled with JavaScript
     foreach($modelNames as $modelName) {
       $model = classRegistry::init($modelName);
+      $arr=explode('.',$modelName);
+      $realModelName=$arr[0];
 
       foreach ($model->validate as $field => $validators) {
         if (array_intersect(array('rule', 'allowEmpty', 'on', 'message', 'last'), array_keys($validators))) {
@@ -97,7 +99,7 @@ class ValidationHelper extends Helper {
               $temp['negate'] = true;
             }
 
-            $validation[$modelName . Inflector::camelize($field)][] = $temp;
+            $validation[$realModelName . Inflector::camelize($field)][] = $temp;
           }
         }
       }

--- a/views/helpers/validation.php
+++ b/views/helpers/validation.php
@@ -256,9 +256,9 @@ class ValidationHelper extends Helper {
       }
       return $regex;
     }
-
-    return array('rule' => $rule, 'params' => $params);
-  }
+    // If not rule is selected handle with a regular expression
+    return($rule);
+}
 
 	function __fixWatch($modelName, $fields) {
 		foreach($fields as $i => $field) {


### PR DESCRIPTION
-When I created a model, and used pure regex rules in the model, it didn't work. For example, ('customer_first_name' => array('rule'=>'/[a-zA-Z]+/','message'=>'First name cannot be empty. Only letters allowed.'). The code seems to validate to create in the script a nested rules like, "'rule':{'rule':'REGEXRULE','params':[]}". I attempted to fix it by overriding the default. 

Another thing I fixed is that the model names don't work right for models in plugins. When you have a plugin model, it is references Plugin.ModelName, but the stuff after the '.' gets removed in the form helper. So, it becoems PluginPluginField as the input field names. I fixed the code of this module to work with that. Possibly, this could be considered a bug with the default Form helper.
